### PR TITLE
Minor fix for shared memory test

### DIFF
--- a/test/cuda/common/shm.c
+++ b/test/cuda/common/shm.c
@@ -13,7 +13,7 @@
 #endif
 
 #include <gdev_api.h> /* just for GDEV_IPC_RMID */
-#define KEY 0xdeadbeef
+#define KEY 0x7eadbeef
 
 int copy_to_shm(unsigned int *in, unsigned int size)
 {


### PR DESCRIPTION
I believe that shared memory test is failing because the value of KEY is being set as 0xdeadbeef, which when treated as a signed integer becomes a negative value. Due to this the following check in gshmget () fails:

```
 if (key < 0 || size == 0)    (key is considered as a signed integer)
            return -EINVAL;
```

The change is to set KEY value to 0x7eadbeef, a non-negative number. With this change, it is working fine for me.
