### PR TITLE
pscnv_gdev.c: Swapped memset parameters (this silences a gcc warning).

### DIFF
--- a/lib/user/pscnv/pscnv_gdev.c
+++ b/lib/user/pscnv/pscnv_gdev.c
@@ -79,7 +79,7 @@ struct gdev_device *gdev_raw_dev_open(int minor)
 		gdevs = MALLOC(sizeof(*gdevs) * GDEV_DEVICE_MAX_COUNT);
 		if (!gdevs)
 			return NULL;
-		memset(gdevs, sizeof(*gdevs) * GDEV_DEVICE_MAX_COUNT, 0);
+		memset(gdevs, 0, sizeof(*gdevs) * GDEV_DEVICE_MAX_COUNT);
 	}
 
 	gdev = &gdevs[minor];


### PR DESCRIPTION
GCC complained about memset with length 0.
